### PR TITLE
Introduces BP parts and adds a `buddypress` template part area

### DIFF
--- a/inc/buddypress-blocks.php
+++ b/inc/buddypress-blocks.php
@@ -501,6 +501,30 @@ function bp_get_default_block_templates() {
 }
 
 /**
+ * Adds a specific template part area for BuddyPress areas.
+ *
+ * @since 1.0.0
+ *
+ * @param array $areas The default WordPress template part areas.
+ * @return array All template part areas.
+ */
+function bp_get_template_part_areas( $areas = array() ) {
+	$areas[] = array(
+		'area'        => 'buddypress',
+		'label'       => _x( 'BuddyPress', 'template part area', 'buddyvibes' ),
+		'description' => __(
+			'The BuddyPress part’s area is used by BuddyPress for specific community template parts.',
+			'buddyvives'
+		),
+		'icon'        => 'layout',
+		'area_tag'    => 'div',
+	);
+
+	return $areas;
+}
+add_filter( 'default_wp_template_part_areas', 'bp_get_template_part_areas' );
+
+/**
  * Adds a title and a description to BP Block Templates found into the theme by the site editor.
  *
  * This function should be moved in `buddypress/src/bp-core/bp-core-template.php`.

--- a/parts/buddypress/member-entry.html
+++ b/parts/buddypress/member-entry.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group">
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
+		<!-- wp:bp/item-avatar {"isLink":true} /-->
+	</div>
+	<!-- /wp:group -->
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
+		<!-- wp:heading {"level":3,"className":"bp-block-item-name member-name"} -->
+		<h3 class="bp-block-item-name member-name">This is where the Member name will appear</h3>
+		<!-- /wp:heading -->
+	</div>
+	<!-- /wp:group -->
+</div>

--- a/templates/buddypress/members/index.html
+++ b/templates/buddypress/members/index.html
@@ -11,22 +11,7 @@
 	<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 	<!-- wp:bp/loop -->
-		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group">
-			<!-- wp:group {"layout":{"inherit":true}} -->
-			<div class="wp-block-group">
-				<!-- wp:bp/item-avatar {"isLink":true} /-->
-			</div>
-			<!-- /wp:group -->
-			<!-- wp:group {"layout":{"inherit":true}} -->
-			<div class="wp-block-group">
-				<!-- wp:heading {"level":3,"className":"bp-block-item-name member-name"} -->
-				<h3 class="bp-block-item-name member-name">This is where the Member name will appear</h3>
-				<!-- /wp:heading -->
-			</div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
+		<!-- wp:template-part {"slug":"buddypress/member-entry","tagName":"article","className":"member-entry"} /-->
 	<!-- /wp:bp/loop -->
 </main>
 <!-- /wp:group -->

--- a/theme.json
+++ b/theme.json
@@ -250,6 +250,11 @@
 			"area": "footer",
 			"name": "footer",
 			"title": "Footer"
+		},
+		{
+			"area": "buddypress",
+			"name": "buddypress/member-entry",
+			"title": "Member’s entry"
 		}
 	]
 }


### PR DESCRIPTION
Moves the member's item part of a Members loop into a specific `parts/buddypress` template part. To use such parts into templates, the code to include a part needs to look like this:

```html
<!-- wp:template-part {"slug":"buddypress/member-entry","tagName":"article","className":"member-entry"} /-->
```

-> The `buddypress` folder needs to be included into the `slug` value.